### PR TITLE
Protospace 31987

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,8 +18,8 @@
         </div>
 
         <div class="field">
-          <%= f.label :encrypted_password, "パスワード再入力" %><br />
-          <%= f.password_field :encrypted_password, autocomplete: "encrypted_password" %>
+          <%= f.label :password_confirmation, "パスワード再入力" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "encrypted_password" %>
         </div>
 
         <div class="field">

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.title %>
       </p>
       <%= link_to "#{@prototype.user.name}", user_path(@prototype.user), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>


### PR DESCRIPTION
# [修正箇所]

新規登録時の「パスワード再入力」欄が空欄でも登録できてしまう。
プロトタイプタイトルが固定値だった。